### PR TITLE
Typo + formatting + required dependencies

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN REPO=$(mktemp /tmp/repo.XXXXXXXXX) && \
 
 # OpenJDK/jar, jq, python-protobuf: android-prepare-vendor
 # signify: required for signing factory images zips.
-RUN apt-get -y install jq openjdk-11-jdk python-protobuf signify 
+RUN apt-get -y install jq openjdk-11-jdk python-protobuf signify rsync
 
 COPY gitconfig /root/.gitconfig
 WORKDIR /src

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN REPO=$(mktemp /tmp/repo.XXXXXXXXX) && \
 
 # OpenJDK/jar, jq, python-protobuf: android-prepare-vendor
 # signify: required for signing factory images zips.
-RUN apt-get -y install jq openjdk-11-jdk python-protobuf signify rsync
+RUN apt-get -y install jq openjdk-11-jdk python-protobuf signify rsync libpulse0
 
 COPY gitconfig /root/.gitconfig
 WORKDIR /src

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,16 +1,20 @@
 The Dockerfile in this directory sets up an Ubuntu Focal image ready to build
 GrapheneOS 11 or better.
 
-First, build the image (use `docker` or `podman`):
+# 1. Build the image
+- Use `docker` or `podman`
 ```
 # Copy your host gitconfig, or create a stripped down version
 $ cp ~/.gitconfig gitconfig
 $ docker build --build-arg userid=$(id -u) --build-arg groupid=$(id -g) --build-arg username=$(id -un) -t android-build-focal .
 ```
 
-Then you can start up new instances with:
+## 2. Start new instances
+- Replace `/path/to/saved/source` with where you want android source code to be saved to
+- `--privileged` is required for `emulator`, enabling KVM to function
+
 ```
-$ docker run -it --rm -v $ANDROID_BUILD_TOP:/src android-build-focal
+$ docker run --privileged -it --rm -v /path/to/saved/source:/src android-build-focal
 > repo init -u https://github.com/GrapheneOS/platform_manifest.git -b 12
 > repo sync -j$(nproc)
 > source script/envsetup.sh

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -10,7 +10,7 @@ $ docker build --build-arg userid=$(id -u) --build-arg groupid=$(id -g) --build-
 
 Then you can start up new instances with:
 ```
-$ docker run -it --rm -v $ANDROID_BUILD_TOP:/src android-buildf-focal
+$ docker run -it --rm -v $ANDROID_BUILD_TOP:/src android-build-focal
 > repo init -u https://github.com/GrapheneOS/platform_manifest.git -b 12
 > repo sync -j$(nproc)
 > source script/envsetup.sh

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -18,3 +18,20 @@ $ docker run -it --rm -v $ANDROID_BUILD_TOP:/src android-build-focal
 ```
 If using `podman` unprivileged containers, also add SELinux relabeling by appending `:Z` to the
 volume map, i.e., `-v foo:bar:Z`.
+
+## Running docker commands without sudo
+The error `Got permission denied while trying to connect to the Docker daemon socket` is commonly resolved by using `sudo`.
+
+Using sudo to build this image may cause problems, such as your `gitconfig` not being included.
+
+To use docker without sudo, you need to add yourself to the `docker` user group:
+
+```
+# Create the docker group, if it doesn't already exist
+$ sudo groupadd docker
+
+# Add your user to this group.
+# If you are not currently logged in to your user account, replace '$USER' with your username
+$ sudo usermod -aG docker $USER
+```
+Now logout and log back in again, and you should be able to use `docker` without `sudo`.


### PR DESCRIPTION
- Correct docker image name typo: `android-buildf-focal` -> `android-build-focal`

- Add `rsync` package to Dockerfile to prevent building images from failing
- Add `libpilse0` package to Dockerfile to enable `emulator` to run successfully

- Add instructions for using docker without sudo